### PR TITLE
added ICACHE_RAM_ATTR on interrupt callback function

### DIFF
--- a/esp8266-co2monitor.ino
+++ b/esp8266-co2monitor.ino
@@ -68,7 +68,7 @@ void setup() {
   mqttConnect();
 }
 
-void onClock() {
+ICACHE_RAM_ATTR void onClock() {
 
   lastMillis = millis();
   bits[bitIndex++] = (digitalRead(PIN_DATA) == HIGH) ? 1 : 0;
@@ -174,4 +174,3 @@ bool decodeDataPackage(byte data[5]) {
   }
 
 }
-


### PR DESCRIPTION
This fixes a problem with new versions of the esp8266 lib, See [Issue](https://github.com/schinken/esp8266-co2monitor/issues/2).