### PR TITLE
Removed */ under second PIN_DATA

### DIFF
--- a/settings.h.example
+++ b/settings.h.example
@@ -8,7 +8,6 @@
  */
 #define PIN_CLK  4 //D2 on PCB
 #define PIN_DATA 5 //D1 on PCB
-*/
 
 const float EXP_SMOOTH_ALPHA = 0.125;
 


### PR DESCRIPTION
The second */ caused a compilation error, removing it made the code compile however I'm not sure if it also works on non-clone-D1 Minis this way.